### PR TITLE
Refactored Login, Register, Logout to not trigger a page reload

### DIFF
--- a/web/src/components/AuthModal.tsx
+++ b/web/src/components/AuthModal.tsx
@@ -22,8 +22,10 @@ interface AuthModalProps extends ModalProps {
 
 const AuthModal: React.FC<AuthModalProps> = ({ type, setType, ...props }) => {
 	let form = null;
-	if (type === 'login') form = <Login setType={setType} />;
-	else if (type === 'sign up') form = <Register setType={setType} />;
+	if (type === 'login')
+		form = <Login setType={setType} onSuccess={props.onClose} />;
+	else if (type === 'sign up')
+		form = <Register setType={setType} onSuccess={props.onClose} />;
 	else if (type === 'forgot password')
 		form = <ForgotPassword setType={setType} />;
 

--- a/web/src/components/UserMenuList.tsx
+++ b/web/src/components/UserMenuList.tsx
@@ -30,8 +30,6 @@ const UserMenuList: React.FC<UserMenuListProps> = ({ openAuthModal, user }) => {
 	const { colorMode, toggleColorMode } = useColorMode();
 	const isDarkMode = colorMode === 'dark';
 
-	console.log(user);
-
 	// The logout mutation has to update the cached user to null
 	const [logout] = useLogoutMutation({
 		update(cache) {
@@ -74,7 +72,6 @@ const UserMenuList: React.FC<UserMenuListProps> = ({ openAuthModal, user }) => {
 						icon={<LogoutIcon size="24px" />}
 						onClick={() => {
 							logout();
-							window.location.reload();
 						}}
 					>
 						<Text>Log Out</Text>


### PR DESCRIPTION
## Summary
Added an 'onSuccess' prop to the Login and Register components which will cause the modal to close when either of those actions success.

In order to update the user without a page reload after they log in or sign up, I had to specify the update option on both queries to update the cache and set the user when the action succeeds

Closes #6 